### PR TITLE
Remove verbosity argument in scheduler

### DIFF
--- a/spotiflow/model/trainer.py
+++ b/spotiflow/model/trainer.py
@@ -425,7 +425,6 @@ class SpotiflowTrainingWrapper(pl.LightningModule):
                 threshold=1e-4,
                 min_lr=3e-6,
                 cooldown=5,
-                verbose=True,
             )
             out["lr_scheduler"] = {
                 "scheduler": scheduler,


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix
- [ ] Feature
- [ ] Optimization
- [ ] Documentation Update

## Description

With `pytorch` 2.7 onwards, `verbose` argument has been removed from learning rate schedulers. The trainings would break with new `pytorch` installation.

cc: @AlbertDominguez @maweigert 
