### PR TITLE
Fix multi-channel 3D volume handling

### DIFF
--- a/spotiflow/augmentations/transforms3d/crop.py
+++ b/spotiflow/augmentations/transforms3d/crop.py
@@ -1,7 +1,6 @@
 from typing import Tuple
 
 import torch
-import torchvision.transforms.functional as tvf
 
 from ..transforms.base import BaseAugmentation
 from ..transforms.utils import _filter_points_idx
@@ -9,22 +8,24 @@ from ..transforms.utils import _filter_points_idx
 
 class Crop3D(BaseAugmentation):
     def __init__(self, size: Tuple[int, int, int], probability: float=1.0, point_priority: float=0):
-        """Augmentation class for random crops
+        """Augmentation class for random crops.
+
+        Assuming the last three dimensions of the image tensor are spatial dimensions (z, y, x).
 
         Args:
             probability (float): probability of applying the augmentation. Must be in [0, 1].
             size (Tuple[int, int]): size of the crop in (z, y, x) format
-            priority (float): prioritizes crops centered around keypoints. Must be in [0, 1]. 
+            priority (float): prioritizes crops centered around keypoints. Must be in [0, 1].
         """
         super().__init__(probability)
         assert len(size) == 3 and all([isinstance(s, int) for s in size]), "Size must be a 3-length tuple of integers"
         self._size = size
         self._point_priority = point_priority
-    
+
     @property
     def size(self) -> Tuple[int, int, int]:
         return self._size
-    
+
     @property
     def point_priority(self) -> float:
         return self._point_priority
@@ -38,17 +39,14 @@ class Crop3D(BaseAugmentation):
         # Crop volume
         img_c = img[..., cz:cz+self.size[0], cy:cy+self.size[1], cx:cx+self.size[2]]
 
-        # # Crop image
-        # img_c = tvf.crop(img, top=cy, left=cx, height=self.size[0], width=self.size[1])
-
         # Crop points
         pts_c = pts - torch.FloatTensor([cz, cy, cx])
         idxs_in = _filter_points_idx(pts_c, self.size)
         return img_c, pts_c[idxs_in].view(*pts.shape[:-2], -1, pts.shape[-1])
-    
+
     def _generate_tl_anchor(self, z: int, y: int, x: int, pts: torch.Tensor) -> Tuple[int, int, int]:
         prob = torch.FloatTensor(1).uniform_(0, 1).item()
-        
+
         if prob>self.point_priority:
             # Randomly generate top-left anchor
             cz, cy, cx = torch.FloatTensor(1).uniform_(0, z-self.size[0]).item(), torch.FloatTensor(1).uniform_(0, y-self._size[1]).item(), torch.FloatTensor(1).uniform_(0, x-self._size[2]).item()
@@ -62,7 +60,7 @@ class Crop3D(BaseAugmentation):
                 # sample randomly if no points are valid
                 cz, cy, cx = torch.FloatTensor(1).uniform_(0, z-self.size[0]).item(), torch.FloatTensor(1).uniform_(0, y-self._size[1]).item(), torch.FloatTensor(1).uniform_(0, x-self._size[2]).item()
             else:
-                # select a point 
+                # select a point
                 center_idx = torch.randint(0, valid_pt_coords.shape[0], (1,)).item()
                 cz, cy, cx = valid_pt_coords[center_idx]
                 cz = cz + torch.randint(-width[0], width[0]+1, (1,))

--- a/spotiflow/augmentations/transforms3d/fliprot.py
+++ b/spotiflow/augmentations/transforms3d/fliprot.py
@@ -49,6 +49,8 @@ class FlipRot903D(BaseAugmentation):
 
     def apply(self, img: torch.Tensor, pts: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
         """Applies FlipRot90 augmentation to the given image and points.
+
+        Assuming the last three dimensions of the image tensor are spatial dimensions (z, y, x).
         """
         # Randomly choose the spatial axis/axes to flip
         combs = tuple(_subgroup_flips(img.ndim, axis=(-3, -2, -1)))

--- a/spotiflow/data/spots3d.py
+++ b/spotiflow/data/spots3d.py
@@ -27,7 +27,9 @@ log.addHandler(console_handler)
 
 
 class Spots3DDataset(SpotsDataset):
-    """Base spot dataset class instantiated with loaded images and centers.
+    """3D spot dataset class instantiated with loaded images and centers.
+
+    For multi-channel images, DHWC (ZYXC) format is expected, but they will be converted to CDHW (CZYX) patches.
 
     Example:
 
@@ -43,15 +45,17 @@ class Spots3DDataset(SpotsDataset):
         if self._defer_normalization:
             img = self._normalizer(img)
 
-        img = torch.from_numpy(img.copy()).unsqueeze(0)  # Add B dimension
-        centers = torch.from_numpy(centers.copy()).unsqueeze(0)  # Add B dimension
+        img = torch.from_numpy(img.copy()).unsqueeze(0)  # Add B (batch) dimension
+        centers = torch.from_numpy(centers.copy()).unsqueeze(0)  # Add B (batch) dimension
 
-        assert img.ndim in (4, 5)  # Images should be in BCDWH or BDHW format
-        if img.ndim == 4:
-            img = img.unsqueeze(1) # Add C dimension
+        assert img.ndim in (4, 5), "Image tensor must be 4D (BDHW) or 5D (BDHWC)."
+        if img.ndim == 4:  # i.e. BDHW, then add C (channel) dimension to BDHW format
+            img = img.unsqueeze(1)
+        if img.ndim == 5:  # i.e. BDHWC, then turn BDWHC format into BCDHW
+            img = torch.moveaxis(img, -1, 1)
 
-        img, centers = self.augmenter(img, centers)
-        img, centers = img.squeeze(0), centers.squeeze(0)  # Remove B dimension
+        img, centers = self.augmenter(img, centers)  # augmenter expects BCDHW format
+        img, centers = img.squeeze(0), centers.squeeze(0)  # Remove B (batch) dimension
 
         if self._compute_flow:
             flow = utils.points_to_flow3d(


### PR DESCRIPTION
**TL;DR**: Training on 3D volumes worked, but using 4D (multi-channel 3D) volumes resulted in errors. This PR resolves the issue by updating `Spots3DDataset`, and only affects 4D inputs.

## What type of PR is this?

- Bug fix
- Minor optimization
- Small docstring update

## Description

Hi @AlbertDominguez, thanks for the great package! The method is very promising, and I’ve been testing Spotiflow on my multi-channel 3D microscopy volumes. While doing so, I noticed that multi-channel inputs are not handled consistently across the codebase—some parts (e.g. PyTorch-based components like augmentations and networks) assume spatial dimensions are last, whereas others place the channel dimension last.

Since I needed to get it working quickly, I made the following minimal changes and tested them on my data:

1. The neural network expects input in the shape (B)(C)(Z)YX, but the loader and much of the rest of the package assume (Z)YX(C). I’ve updated the `Spots3DDataset` class to correctly handle multi-channel 3D input.
2. I added small comments in the `transforms3d/*.py` files to clarify that the functions expect their input shaped as `[..., Z, Y, X]`.
3. I made a minor improvement to the initialisation of both `Spots3DDataset` and `SpotsDataset`. Introducing an `AbstractSpotDataset` base class for both could be a further enhancement.

I hope this helps make training with multi-channel 3D data semantically correct and easier to use. Looking forward to your feedback!

## Related issues (if applicable)

- Related Issue #33
- Closes #33
