### PR TITLE
Add `--channels` argument to training and prediction CLI for channel selection

### DIFF
--- a/spotiflow/cli/predict.py
+++ b/spotiflow/cli/predict.py
@@ -219,12 +219,10 @@ def main():
     else:
         model = Spotiflow.from_pretrained(args.pretrained_model)
 
-
     if model.config.in_channels > 1 and args.estimate_params:
         raise ValueError(
             "Estimating parameters is only supported for single-channel input models. Please set --estimate-params to False."
         )
-
 
     if model.config.in_channels > 1:
         log.warning(
@@ -243,9 +241,9 @@ def main():
     # Check if data_path is a file or directory
     # If it's a file , check if it is a valid image file
     if args.data_path.is_file():
-        assert (
-            args.data_path.suffix[1:] in ALLOWED_EXTENSIONS
-        ), f"File {args.data_path} is not a valid image file. Allowed extensions are: {ALLOWED_EXTENSIONS}"
+        assert args.data_path.suffix[1:] in ALLOWED_EXTENSIONS, (
+            f"File {args.data_path} is not a valid image file. Allowed extensions are: {ALLOWED_EXTENSIONS}"
+        )
         image_files = [args.data_path]
         if out_dir is None:
             out_dir = args.data_path.parent / "spotiflow_results"

--- a/spotiflow/cli/predict.py
+++ b/spotiflow/cli/predict.py
@@ -180,8 +180,9 @@ def get_args():
         type=int,
         required=False,
         default=None,
-        help="List of channels to use for prediction. If None, will use all channels. "
-        "This is only relevant for multi-channel images. Defaults to None.",
+        help="List of channels to use for prediction. "
+        "0 will be interpreted as the first channel, 1 as the second, etc. "
+        "This is only relevant for multi-channel images. If None, will use all channels. Defaults to None.",
     )
 
     utils = parser.add_argument_group(
@@ -323,10 +324,10 @@ def main():
             df["intensity"] = np.round(details.intens, 2)
         df["probability"] = np.round(details.prob, 3)
         if args.estimate_params:
-            df['fwhm'] = np.round(details.fit_params.fwhm, 3)
-            df['intens_A'] = np.round(details.fit_params.intens_A, 3)
-            df['intens_B'] = np.round(details.fit_params.intens_B, 3)
-            df['snb'] = np.round(signal_to_background(details.fit_params), 3)
+            df["fwhm"] = np.round(details.fit_params.fwhm, 3)
+            df["intens_A"] = np.round(details.fit_params.intens_A, 3)
+            df["intens_B"] = np.round(details.fit_params.intens_B, 3)
+            df["snb"] = np.round(signal_to_background(details.fit_params), 3)
 
         df.to_csv(out_dir / f"{fname.stem}.csv", index=False)
     return 0

--- a/spotiflow/cli/train.py
+++ b/spotiflow/cli/train.py
@@ -24,7 +24,9 @@ console_handler.setFormatter(formatter)
 log.addHandler(console_handler)
 
 ALLOWED_EXTENSIONS = ("tif", "tiff", "png", "jpg", "jpeg")
-PRETRAINED_MODELS = tuple(["general"]+sorted([m for m in list_registered() if m != "general"]))
+PRETRAINED_MODELS = tuple(
+    ["general"] + sorted([m for m in list_registered() if m != "general"])
+)
 
 
 def get_data(
@@ -58,7 +60,6 @@ def get_args() -> argparse.Namespace:
         type=Path,
         help="Path to directory containing images and annotations. Please refer to the documentation (https://weigertlab.github.io/spotiflow/train.html#data-format) to see the required format.",
     )
-        
     required.add_argument(
         "-o",
         "--outdir",
@@ -128,20 +129,19 @@ def get_args() -> argparse.Namespace:
         default=2,
         help="Factor to increase the number of feature maps per level. Lower values will yield smaller models, at the potential cost of performance. Defaults to 2.",
     )
+
     train_args = parser.add_argument_group(
         title="Training arguments",
         description="Arguments to configure the training process.",
     )
-    
     train_args.add_argument(
         "--subfolder",
         type=Path,
         nargs=2,
         required=False,
-        default=['train', 'val'],
+        default=["train", "val"],
         help="Subfolder names for training and validation data. Defaults to ['train', 'val'].",
     )
-
     train_args.add_argument(
         "--train_samples",
         type=int,
@@ -149,7 +149,6 @@ def get_args() -> argparse.Namespace:
         default=None,
         help="Number of training samples per epoch (defaults to None, which means all samples).",
     )
-
     train_args.add_argument(
         "--crop-size",
         type=int,
@@ -188,7 +187,6 @@ def get_args() -> argparse.Namespace:
         default=True,
         help="Apply data augmentation during training. Defaults to True.",
     )
-    
     train_args.add_argument(
         "--pos-weight",
         type=float,
@@ -244,19 +242,27 @@ def main():
     pl.seed_everything(args.seed, workers=True)
 
     log.info("Loading training data...")
-    train_images, train_spots = get_data(args.data_dir / args.subfolder[0], is_3d=args.is_3d)
+    train_images, train_spots = get_data(
+        args.data_dir / args.subfolder[0], is_3d=args.is_3d
+    )
     if len(train_images) != len(train_spots):
-        raise ValueError(f"Number of images and spots in {args.data_dir/'train'} do not match.")
+        raise ValueError(
+            f"Number of images and spots in {args.data_dir / 'train'} do not match."
+        )
     if len(train_images) == 0:
-        raise ValueError(f"No images were found in the {args.data_dir/'train'}.")
+        raise ValueError(f"No images were found in the {args.data_dir / 'train'}.")
     log.info(f"Training data loaded (N={len(train_images)}).")
 
     log.info("Loading validation data...")
-    val_images, val_spots = get_data(args.data_dir / args.subfolder[1], is_3d=args.is_3d)
+    val_images, val_spots = get_data(
+        args.data_dir / args.subfolder[1], is_3d=args.is_3d
+    )
     if len(val_images) != len(val_spots):
-        raise ValueError(f"Number of images and spots in {args.data_dir/'val'} do not match.")
+        raise ValueError(
+            f"Number of images and spots in {args.data_dir / 'val'} do not match."
+        )
     if len(val_images) == 0:
-        raise ValueError(f"No images were found in the {args.data_dir/'val'}.")
+        raise ValueError(f"No images were found in the {args.data_dir / 'val'}.")
     log.info(f"Validation data loaded (N={len(val_images)}).")
 
     if args.finetune_from is None:
@@ -318,7 +324,7 @@ def main():
             "lr": args.lr,
             "num_epochs": args.num_epochs,
             "pos_weight": args.pos_weight,
-            "num_train_samples":args.train_samples,
+            "num_train_samples": args.train_samples,
             "finetuned_from": args.finetune_from,
             "smart_crop": args.smart_crop,
         },

--- a/spotiflow/cli/train.py
+++ b/spotiflow/cli/train.py
@@ -236,8 +236,9 @@ def get_args() -> argparse.Namespace:
         type=int,
         required=False,
         default=None,
-        help="List of channels to use for training. If None, will use all channels. "
-        "This is only relevant for multi-channel images. Defaults to None.",
+        help="List of channels to use for training. "
+        "0 will be interpreted as the first channel, 1 as the second, etc. "
+        "This is only relevant for multi-channel images. If None, will use all channels. Defaults to None.",
     )
     args = parser.parse_args()
     return args

--- a/spotiflow/model/trainer.py
+++ b/spotiflow/model/trainer.py
@@ -33,7 +33,7 @@ def _img_to_rgb_or_gray(x: torch.Tensor):
     if n_channels in (1, 3):
         return x
     elif n_channels == 2:
-        return torch.cat((x[:1], x[1:], x[:1]), dim=0)
+        return np.concatenate((x[:1], x[1:], x[:1]), axis=0)
     else:
         _cs = np.linspace(0, n_channels - 1, 3).astype(int)
         return x[_cs]

--- a/spotiflow/utils/utils.py
+++ b/spotiflow/utils/utils.py
@@ -32,6 +32,10 @@ def imread_wrapped(fname, channels=None):
     try:
         img = imread(fname)
         if channels is not None:
+            if any(c >= img.shape[-1] for c in channels):
+                raise ValueError(
+                    f"Some of the requested channels {channels} are not present in the image {fname} with shape {img.shape}"
+                )
             if len(channels) == 1:
                 img = img[..., channels[0]]
             else:
@@ -449,7 +453,7 @@ def remove_device_id_from_device_str(device_str: str) -> str:
 def get_data(
     path: Union[Path, str],
     normalize: bool = True,
-    subfolder: tuple[str] = ('train', 'val', 'test'),
+    subfolder: tuple[str] = ("train", "val", "test"),
     is_3d: bool = False,
     **kwargs,
 ) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
@@ -476,8 +480,8 @@ def get_data(
                 f"Given data path {path} does not contain a '{sub}' folder!"
             )
 
-    if not normalize and not 'normalizer' in kwargs:
-        kwargs['normalizer'] = None
+    if not normalize and not "normalizer" in kwargs:
+        kwargs["normalizer"] = None
 
     datasets = tuple(
         SpotsDatasetClass.from_folder(path / sub, add_class_label=False, **kwargs)
@@ -684,7 +688,7 @@ def spline_interp_points_2d(
                     img[..., c],
                     [y_coords, x_coords],
                     order=order,
-                    mode='reflect',
+                    mode="reflect",
                     prefilter=False,
                 )
                 for c in range(img.shape[2])
@@ -693,7 +697,7 @@ def spline_interp_points_2d(
         )
     else:
         intensities = ndi.map_coordinates(
-            img, [y_coords, x_coords], order=order, mode='reflect', prefilter=False
+            img, [y_coords, x_coords], order=order, mode="reflect", prefilter=False
         )
     return intensities
 

--- a/spotiflow/utils/utils.py
+++ b/spotiflow/utils/utils.py
@@ -14,6 +14,7 @@ import scipy.ndimage as ndi
 import torch
 import wandb
 from csbdeep.utils import normalize_mi_ma
+from skimage.io import imread
 from torch.utils.data import Dataset
 
 log = logging.getLogger(__name__)
@@ -24,6 +25,21 @@ console_handler.setLevel(logging.INFO)
 formatter = logging.Formatter("%(levelname)s:%(name)s:%(message)s")
 console_handler.setFormatter(formatter)
 log.addHandler(console_handler)
+
+
+def imread_wrapped(fname, channels=None):
+    """Note that multi-channel images have to have the channels in the last dimension."""
+    try:
+        img = imread(fname)
+        if channels is not None:
+            if len(channels) == 1:
+                img = img[..., channels[0]]
+            else:
+                img = img[..., channels]
+        return img
+    except Exception as e:
+        log.error(f"Could not read image {fname}. Execution will halt.")
+        raise e
 
 
 def str2bool(value):


### PR DESCRIPTION
Hi @AlbertDominguez, while working on my experiments, I updated the code to avoid duplicating thousands of images just to select specific channels during large-scale inference. I applied the same logic to the training CLI, so I can now test different channel combinations simply by adjusting the new `--channels` parameter.

## What type of PR is this?

- [x] Feature

## Description

This PR introduces a `-c` / `--channels` argument to both the training and prediction CLI. This addition:

- Eliminates the need to duplicate image files when selecting input channels.
- Simplifies experiments with combinations of auxiliary channels during training.
- Should work for both 2D and 3D images.

I tested with my multi-channel 3D dataset. The commits have been split and squashed into two to isolate the actual changes in d236b0c7e191264522bf5f8e3ed4de090654b5cd. Syntactic changes are Black and `argparse` grouping.